### PR TITLE
Enhance visual pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -574,6 +574,15 @@ input[type="range"]::-webkit-slider-thumb {
     background: #5568c4;
 }
 
+.linked-list-controls .control-group {
+    margin-bottom: 10px;
+}
+
+.linked-list-controls input[type="text"],
+.linked-list-controls input[type="number"] {
+    width: 120px;
+}
+
 .ll-node-container {
     display: flex;
     align-items: center; /* Align node and arrow horizontally */
@@ -804,4 +813,57 @@ input[type="range"]::-webkit-slider-thumb {
 .mst-edge.selected {
     color: #44a08d;
     font-weight: bold;
+}
+
+/* Graph Visualization */
+.graph-viz {
+    position: relative;
+    background: #ffffff;
+    border: 2px solid #e9ecef;
+    border-radius: 10px;
+    height: 400px;
+    overflow: hidden;
+}
+
+.graph-node {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #667eea;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    cursor: pointer;
+    user-select: none;
+}
+
+.graph-edge {
+    position: absolute;
+    height: 2px;
+    background: #333;
+    transform-origin: 0 50%;
+}
+
+.graph-edge.directed::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    border: solid #333;
+    border-width: 0 2px 2px 0;
+    padding: 4px;
+}
+
+.edge-weight {
+    position: absolute;
+    background: #f8f9fa;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    border: 1px solid #ccc;
+    transform: translate(-50%, -50%);
 }

--- a/js/common.js
+++ b/js/common.js
@@ -15,6 +15,8 @@ class AnimationController {
             this.speedInput = speedInput;
         }
 
+        this.animationSpeed = this.baseDelay;
+
         this._paused = false;
         this.currentStep = 0;
         this.animationSteps = [];
@@ -46,6 +48,7 @@ class AnimationController {
         this._speed = speed;
         // Higher speed -> shorter delay
         this.baseDelay = 1100 - speed * 100;
+        this.animationSpeed = this.baseDelay;
         return this;
     }
 

--- a/pages/counting-stairs.html
+++ b/pages/counting-stairs.html
@@ -27,6 +27,7 @@
                 <button id="cs-start">Run Demo</button>
                 <button id="cs-reset">Reset</button>
             </div>
+            <div class="control-group" id="cs-anim-controls"></div>
         </div>
         <div class="visualization-area">
             <div class="matrix-container">
@@ -91,6 +92,9 @@
                     }
                     setTimeout(()=>cell.classList.remove('highlight-access'), controller.animationSpeed);
                 });
+
+            document.getElementById('cs-anim-controls')
+                .appendChild(createAnimationControls(controller));
 
             document.getElementById('cs-start').addEventListener('click', () => controller.play());
             document.getElementById('cs-reset').addEventListener('click', () => {

--- a/pages/dp-knapsack.html
+++ b/pages/dp-knapsack.html
@@ -27,6 +27,7 @@
                 <button id="knap-start">Run Demo</button>
                 <button id="knap-reset">Reset</button>
             </div>
+            <div class="control-group" id="knap-anim-controls"></div>
         </div>
         <div class="visualization-area">
             <div class="matrix-container">
@@ -90,6 +91,9 @@
                     cell.classList.add('highlight-access');
                     setTimeout(()=>cell.classList.remove('highlight-access'), controller.animationSpeed);
                 });
+
+            document.getElementById('knap-anim-controls')
+                .appendChild(createAnimationControls(controller));
 
             document.getElementById('knap-start').addEventListener('click', () => controller.play());
             document.getElementById('knap-reset').addEventListener('click', () => {

--- a/pages/linked-list.html
+++ b/pages/linked-list.html
@@ -23,7 +23,7 @@
             <p>Visualize common linked list operations like insertion, deletion, and traversal.</p>
         </div>
                 <div class="content-wrapper">
-            <div class="controls">
+            <div class="controls linked-list-controls">
                 <h2>Controls</h2>
                 <div class="control-group">
                     <input type="text" id="list-value" placeholder="Enter value">
@@ -627,9 +627,14 @@
                     });
                 }
 
-                // Initial render
-                list.render();
-                logOperation('Linked list visualization initialized.');
+                // Seed with default values
+                (async () => {
+                    await list.insertTail('A');
+                    await list.insertTail('B');
+                    await list.insertTail('C');
+                    list.render();
+                    logOperation('Linked list visualization initialized with sample data.');
+                })();
             });
         </script>
 

--- a/pages/painting-houses.html
+++ b/pages/painting-houses.html
@@ -27,6 +27,7 @@
                 <button id="ph-start">Run Demo</button>
                 <button id="ph-reset">Reset</button>
             </div>
+            <div class="control-group" id="ph-anim-controls"></div>
         </div>
         <div class="visualization-area">
             <div class="matrix-container">
@@ -94,6 +95,9 @@
                     cell.classList.add('highlight-access');
                     setTimeout(()=>cell.classList.remove('highlight-access'), controller.animationSpeed);
                 });
+
+            document.getElementById('ph-anim-controls')
+                .appendChild(createAnimationControls(controller));
 
             document.getElementById('ph-start').addEventListener('click', () => controller.play());
             document.getElementById('ph-reset').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- style graph elements so DFS/BFS visuals display correctly
- expose animation speed in `AnimationController`
- seed linked list demo with sample values and tweak layout
- add animation control panels to knapsack, painting houses, and counting stairs demos

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684109f311f08331854ccafc95351490